### PR TITLE
Add filtering of "Promoted" spans

### DIFF
--- a/content.js
+++ b/content.js
@@ -8,7 +8,7 @@ var youMightLikeSvgPath = 'M18.265 3.314c-3.45-3.45-9.07-3.45-12.52 0-3.45 3.44-
 
 function getAds() {
   return Array.from(document.querySelectorAll('div')).filter(function(el) {
-    var filteredAd;
+   var filteredAd;
 
     if (el.getInnerHTML().includes(sponsoredSvgPath)) {
       filteredAd = el;
@@ -17,9 +17,8 @@ function getAds() {
     } else if (el.innerText == 'Promoted Tweet') { // TODO: bring back multi-lingual support from git history
       filteredAd = el;
     }
-
     return filteredAd;
-  })
+  }).concat(Array.from(document.querySelectorAll('span')).filter(s=>s.getInnerHTML().includes('Promoted')))
 }
 
 function hideAd(ad) {
@@ -35,7 +34,7 @@ function hideAd(ad) {
   } else if (ad.closest(articleSelector) !== null) {
     ad.closest(articleSelector).remove();
     adsHidden += 1;
-  } else if (ad.innerText == 'Promoted Tweet') {
+  } else if (ad.innerText == 'Promoted By') {
     ad.remove();
     adsHidden += 1;
   }
@@ -53,3 +52,4 @@ new PerformanceObserver((entryList) => {
 
 // re-check as user scrolls
 document.addEventListener('scroll', () => getAds().forEach(hideAd));
+


### PR DESCRIPTION
Twitter have made change to their tweet structure for Promoted tweets that has broken the current filtering.  Some "Promoted" tweets now have that text in a span, not a div, so it gets missed by the filter.

I have tested this on my chrome browser and it works, but might need to tighten up the condition for adding spans to the array of ads. (which is currently span.getInnerHTML().contains('Promoted')).  

